### PR TITLE
Add PlaidML Execution Provider

### DIFF
--- a/cmake/onnxruntime.cmake
+++ b/cmake/onnxruntime.cmake
@@ -80,6 +80,7 @@ target_link_libraries(onnxruntime PRIVATE
     ${PROVIDERS_NUPHAR}
     ${PROVIDERS_DML}
     ${PROVIDERS_ACL}
+    ${PROVIDERS_PLAIDML}
     ${onnxruntime_winml}
     onnxruntime_optimizer
     onnxruntime_providers

--- a/cmake/onnxruntime_providers.cmake
+++ b/cmake/onnxruntime_providers.cmake
@@ -77,6 +77,10 @@ if(onnxruntime_USE_ACL)
   set(PROVIDERS_ACL onnxruntime_providers_acl)
   list(APPEND ONNXRUNTIME_PROVIDER_NAMES acl)
 endif()
+if(onnxruntime_USE_PLAIDML)
+  set(PROVIDERS_PLAIDML onnxruntime_providers_plaidml)
+  list(APPEND ONNXRUNTIME_PROVIDER_NAMES plaidml)
+endif()
 source_group(TREE ${ONNXRUNTIME_ROOT}/core FILES ${onnxruntime_providers_common_srcs} ${onnxruntime_providers_srcs})
 
 set(onnxruntime_providers_src ${onnxruntime_providers_common_srcs} ${onnxruntime_providers_srcs})
@@ -487,6 +491,21 @@ if (onnxruntime_USE_ACL)
   target_include_directories(onnxruntime_providers_acl PRIVATE ${ONNXRUNTIME_ROOT} ${eigen_INCLUDE_DIRS} ${ACL_INCLUDE_DIR})
   install(DIRECTORY ${PROJECT_SOURCE_DIR}/../include/onnxruntime/core/providers/acl  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/onnxruntime/core/providers)
   set_target_properties(onnxruntime_providers_acl PROPERTIES LINKER_LANGUAGE CXX)
+endif()
+
+if (onnxruntime_USE_PLAIDML)
+  file(GLOB_RECURSE onnxruntime_providers_plaidml_cc_srcs CONFIGURE_DEPENDS
+    "${ONNXRUNTIME_ROOT}/core/providers/plaidml/*.h"
+    "${ONNXRUNTIME_ROOT}/core/providers/plaidml/*.cc"
+  )
+
+  source_group(TREE ${ONNXRUNTIME_ROOT}/core FILES ${onnxruntime_providers_plaidml_cc_srcs})
+  add_library(onnxruntime_providers_plaidml ${onnxruntime_providers_plaidml_cc_srcs})
+  onnxruntime_add_include_to_target(onnxruntime_providers_plaidml onnxruntime_common onnxruntime_framework onnx onnx_proto protobuf::libprotobuf)
+  # TODO: add_dependencies
+  set_target_properties(onnxruntime_providers_plaidml PROPERTIES FOLDER "ONNXRuntime")
+  # TODO: target_include_directories
+  set_target_properties(onnxruntime_providers_plaidml PROPERTIES LINKER_LANGUAGE CXX)
 endif()
 
 if (onnxruntime_ENABLE_MICROSOFT_INTERNAL)

--- a/cmake/onnxruntime_providers.cmake
+++ b/cmake/onnxruntime_providers.cmake
@@ -507,11 +507,9 @@ if (onnxruntime_USE_PLAIDML)
   add_dependencies(onnxruntime_providers_plaidml ${onnxruntime_EXTERNAL_DEPENDENCIES})
 
   set_target_properties(onnxruntime_providers_plaidml PROPERTIES FOLDER "ONNXRuntime")
-  # TODO: target_include_directories probably belongs up here?
   set_target_properties(onnxruntime_providers_plaidml PROPERTIES LINKER_LANGUAGE CXX)
 
   # TODO: This is a HACK to just get something running. It requires a mac and setting some awkward temporary environment variables
-  # TODO: Do I need PRIVATE in target_link_libraries?
   # To make the hack work: Make sure the temp env vars are set. First to root of PlaidML source;
   #       second to library location (which should be something your mac can find eg ~/lib)
   target_include_directories(onnxruntime_providers_plaidml PRIVATE $ENV{TODO_TEMP_PLAIDML_DIR})

--- a/cmake/onnxruntime_providers.cmake
+++ b/cmake/onnxruntime_providers.cmake
@@ -494,6 +494,7 @@ if (onnxruntime_USE_ACL)
 endif()
 
 if (onnxruntime_USE_PLAIDML)
+  add_definitions(-DUSE_PLAIDML=1)
   file(GLOB_RECURSE onnxruntime_providers_plaidml_cc_srcs CONFIGURE_DEPENDS
     "${ONNXRUNTIME_ROOT}/core/providers/plaidml/*.h"
     "${ONNXRUNTIME_ROOT}/core/providers/plaidml/*.cc"

--- a/cmake/onnxruntime_providers.cmake
+++ b/cmake/onnxruntime_providers.cmake
@@ -502,10 +502,21 @@ if (onnxruntime_USE_PLAIDML)
   source_group(TREE ${ONNXRUNTIME_ROOT}/core FILES ${onnxruntime_providers_plaidml_cc_srcs})
   add_library(onnxruntime_providers_plaidml ${onnxruntime_providers_plaidml_cc_srcs})
   onnxruntime_add_include_to_target(onnxruntime_providers_plaidml onnxruntime_common onnxruntime_framework onnx onnx_proto protobuf::libprotobuf)
-  # TODO: add_dependencies
+  # TODO: Verify add_dependencies as follows is right
+  add_dependencies(onnxruntime_providers_plaidml ${onnxruntime_EXTERNAL_DEPENDENCIES})
+
   set_target_properties(onnxruntime_providers_plaidml PROPERTIES FOLDER "ONNXRuntime")
-  # TODO: target_include_directories
+  # TODO: target_include_directories probably belongs up here?
   set_target_properties(onnxruntime_providers_plaidml PROPERTIES LINKER_LANGUAGE CXX)
+
+  # TODO: This is a HACK to just get something running. It requires a mac and setting some awkward temporary environment variables
+  # TODO: Do I need PRIVATE in target_link_libraries?
+  # To make the hack work: Make sure the temp env vars are set. First to root of PlaidML source;
+  #       second to library location (which should be something your mac can find eg ~/lib)
+  target_include_directories(onnxruntime_providers_plaidml PRIVATE $ENV{TODO_TEMP_PLAIDML_DIR})
+  target_link_libraries(onnxruntime_providers_plaidml PRIVATE $ENV{TODO_TEMP_PLAIDML_LIB_DIR}/libplaidml.dylib)
+
+
 endif()
 
 if (onnxruntime_ENABLE_MICROSOFT_INTERNAL)

--- a/cmake/onnxruntime_python.cmake
+++ b/cmake/onnxruntime_python.cmake
@@ -81,6 +81,7 @@ set(onnxruntime_pybind11_state_libs
     ${PROVIDERS_NUPHAR}
     ${PROVIDERS_NNAPI}
     ${PROVIDERS_DML}
+    ${PROVIDERS_PLAIDML}
     onnxruntime_optimizer
     onnxruntime_providers
     onnxruntime_util

--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -163,6 +163,13 @@ if (onnxruntime_USE_NNAPI)
   list(APPEND onnxruntime_test_providers_src ${onnxruntime_test_providers_nnapi_src})
 endif()
 
+if (onnxruntime_USE_PLAIDML)
+  file(GLOB_RECURSE onnxruntime_test_providers_plaidml_src CONFIGURE_DEPENDS
+    "${TEST_SRC_DIR}/providers/plaidml/*"
+    )
+  list(APPEND onnxruntime_test_providers_src ${onnxruntime_test_providers_plaidml_src})
+endif()
+
 set (ONNXRUNTIME_SHARED_LIB_TEST_SRC_DIR "${ONNXRUNTIME_ROOT}/test/shared_lib")
 
 
@@ -271,6 +278,10 @@ if(onnxruntime_USE_ACL)
   list(APPEND onnxruntime_test_providers_dependencies onnxruntime_providers_acl)
 endif()
 
+if(onnxruntime_USE_PLAIDML)
+  list(APPEND onnxruntime_test_providers_dependencies onnxruntime_providers_plaidml)
+endif()
+
 if (onnxruntime_ENABLE_MICROSOFT_INTERNAL)
   include(onnxruntime_unittests_internal.cmake)
 endif()
@@ -292,6 +303,7 @@ set(ONNXRUNTIME_TEST_LIBS
     ${PROVIDERS_NNAPI}
     ${PROVIDERS_DML}
     ${PROVIDERS_ACL}
+    ${PROVIDERS_PLAIDML}
     onnxruntime_optimizer
     onnxruntime_providers
     onnxruntime_util

--- a/include/onnxruntime/core/graph/constants.h
+++ b/include/onnxruntime/core/graph/constants.h
@@ -22,6 +22,7 @@ constexpr const char* kMSNchwcDomain = "com.microsoft.nchwc";
 constexpr const char* kMSFeaturizersDomain = "com.microsoft.mlfeaturizers";
 constexpr const char* kMSDmlDomain = "com.microsoft.dml";
 constexpr const char* kNGraphDomain = "com.intel.ai";
+constexpr const char* kPlaidMLDomain = "com.intel.plaidml";  // TODO: Do I actually want this?
 constexpr const char* kCpuExecutionProvider = "CPUExecutionProvider";
 constexpr const char* kCudaExecutionProvider = "CUDAExecutionProvider";
 constexpr const char* kDnnlExecutionProvider = "DnnlExecutionProvider";

--- a/include/onnxruntime/core/graph/constants.h
+++ b/include/onnxruntime/core/graph/constants.h
@@ -33,4 +33,5 @@ constexpr const char* kTensorrtExecutionProvider = "TensorrtExecutionProvider";
 constexpr const char* kNnapiExecutionProvider = "NnapiExecutionProvider";
 constexpr const char* kDmlExecutionProvider = "DmlExecutionProvider";
 constexpr const char* kAclExecutionProvider = "ACLExecutionProvider";
+constexpr const char* kPlaidMLExecutionProvider = "PlaidMLExecutionProvider";
 }  // namespace onnxruntime

--- a/include/onnxruntime/core/providers/plaidml/plaidml_provider_factory.h
+++ b/include/onnxruntime/core/providers/plaidml/plaidml_provider_factory.h
@@ -1,0 +1,14 @@
+// Copyright(C) 2020 Intel Corporation
+// Licensed under the MIT License
+
+#include "onnxruntime_c_api.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+ORT_API_STATUS(OrtSessionOptionsAppendExecutionProvider_PlaidML, _In_ OrtSessionOptions* options);
+
+#ifdef __cplusplus
+}
+#endif

--- a/onnxruntime/core/providers/plaidml/plaidml_execution_provider.cc
+++ b/onnxruntime/core/providers/plaidml/plaidml_execution_provider.cc
@@ -15,13 +15,18 @@ namespace onnxruntime {
 
 // TODO: Some of this stuff should probably be separated into new files
 std::vector<plaidml::edsl::Tensor> MakePlaidMLOp(
-    const ONNX_NAMESPACE::NodeProto& /*node*/,
+    const ONNX_NAMESPACE::NodeProto& node,
     const std::vector<plaidml::edsl::Tensor>& inputs) {
-  // TODO: THIS ASSUMES EVERY OP IS AN ELEMENTWISE ADD!! OBVIOUSLY THAT'S NOT TRUE!
+  // TODO: This needs to be _way_ more sophisticated (probably broken out into a parsing function and then many op-calling functions)
   if (inputs.size() != 2) {
     throw std::runtime_error(" TODO FORCED ABORT!: We have " + std::to_string(inputs.size()) + " inputs");
   }
-  return {inputs[0] + inputs[1]};
+  if (node.op_type() == "Add") {
+    return {inputs[0] + inputs[1]};
+  } else if (node.op_type() == "Mul") {
+    return {inputs[0] * inputs[1]};
+  }
+  throw std::runtime_error("Unable to handle operation " + node.op_type());
 }
 
 PlaidMLProgram MakePlaidMLProgram(const onnxruntime::Node* fused_node) {

--- a/onnxruntime/core/providers/plaidml/plaidml_execution_provider.cc
+++ b/onnxruntime/core/providers/plaidml/plaidml_execution_provider.cc
@@ -1,24 +1,106 @@
 // Copyright(C) 2020 Intel Corporation
 // Licensed under the MIT License
 
-// TODO: Other includes?
-#include "core/framework/compute_capability.h"
-#include "core/graph/model.h"
-
-#include "core/framework/allocatormgr.h"  // TODO: For DeviceAllocatorRegistrationInfo
-
-// TODO: Actually use this
-#include "plaidml/edsl/edsl.h"
-
 #include "plaidml_execution_provider.h"
 
+#include "plaidml/edsl/edsl.h"
+#include "plaidml/exec/exec.h"
+
+#include "core/framework/allocatormgr.h"
+#include "core/framework/compute_capability.h"
+#include "core/graph/model.h"
+#include "core/session/onnxruntime_cxx_api.h"
+
 namespace onnxruntime {
+
+// TODO: Some of this stuff should probably be separated into new files
+std::vector<plaidml::edsl::Tensor> MakePlaidMLOp(
+    const ONNX_NAMESPACE::NodeProto& /*node*/,
+    const std::vector<plaidml::edsl::Tensor>& inputs) {
+  // TODO: THIS ASSUMES EVERY OP IS AN ELEMENTWISE ADD!! OBVIOUSLY THAT'S NOT TRUE!
+  if (inputs.size() != 2) {
+    throw std::runtime_error(" TODO FORCED ABORT!: We have " + std::to_string(inputs.size()) + " inputs");
+  }
+  return {inputs[0] + inputs[1]};
+}
+
+PlaidMLProgram MakePlaidMLProgram(const onnxruntime::Node* fused_node) {
+  PlaidMLProgram ret;
+  std::map<std::string, plaidml::edsl::Tensor> tensors;
+  // TODO: We might instead implement this on an ONNX ModelProto instead of an ONNX RT Node.
+  //     This might have benefits for reuse in a non-RT ONNX context?
+
+  // TODO: In general, inputs are a mix of initializers and input data; this currently assumes they're all the latter
+
+  // For each input, look up shape (or at least rank) and construct a (placeholder) tensor accordingly;
+  // add this to the `tensors` dict
+  for (const auto& node_input : fused_node->InputDefs()) {
+    // TODO: A node_input's Shape can be nullptr (i.e. if the input isn't a tensor) and we need to handle that case
+    // TODO: This doesn't address symbolic shapes
+    std::vector<int64_t> shape;
+    for (int dim = 0; dim < node_input->Shape()->dim_size(); dim++) {
+      shape.push_back(node_input->Shape()->dim(dim).dim_value());
+    }
+    auto input_placeholder = plaidml::edsl::Placeholder(plaidml::DType::FLOAT32, shape);
+    if (!tensors.insert({node_input->Name(), input_placeholder}).second) {
+      throw std::runtime_error("Unexpected duplicate name in fused node while adding inputs [TODO better error handling]");
+    }
+    ret.inputs.push_back(input_placeholder);
+  }
+
+  // For each node in topological order:
+  //   * Get its inputs out of the `tensors` dict
+  //   * Call `MakePlaidMLOp` and write results into `tensors` dict
+  for (const auto& node : fused_node->GetFunctionBody()->Body().Nodes()) {
+    std::vector<plaidml::edsl::Tensor> local_input_tensors;
+    for (const auto& local_input : node.InputDefs()) {
+      try {
+        local_input_tensors.push_back(tensors.at(local_input->Name()));
+      } catch (const std::out_of_range& e) {
+        throw std::runtime_error("Could not find expected tensor " + local_input->Name() + " [TODO better error handling]");
+      }
+    }
+    ONNX_NAMESPACE::NodeProto node_proto;
+    node.ToProto(node_proto);
+    auto local_output_tensors = MakePlaidMLOp(node_proto, local_input_tensors);
+    // Iterate over output tensors and names in tandem
+    auto output_tensor_it = local_output_tensors.begin();
+    for (const auto& local_output : node.OutputDefs()) {
+      if (output_tensor_it == local_output_tensors.end()) {
+        throw std::runtime_error("Inconsistent number of outputs [TODO better error handling]");
+      }
+      if (!tensors.insert({
+          local_output->Name(),
+          *output_tensor_it
+      }).second) {
+        throw std::runtime_error("Unexpected duplicate name in fused node while adding outputs (possibly intermediate) [TODO better error handling]");
+      }
+      output_tensor_it++;
+    }
+    if (output_tensor_it != local_output_tensors.end()) {
+      throw std::runtime_error("Inconsistent number of outputs [TODO better error handling]");
+    }
+  }
+
+  // Lookup outputs from `tensors` dict, use those to call edsl::ProgramBuilder
+  std::vector<plaidml::edsl::Tensor> output_tensors;
+  for (const auto& node_output : fused_node->OutputDefs()) {
+    auto local_output_tensor_it = tensors.find(node_output->Name());
+    if (local_output_tensor_it == tensors.end()) {
+      throw std::runtime_error("Expected output tensor " + node_output->Name() + " not found [TODO better error handling]");
+    }
+    output_tensors.push_back(local_output_tensor_it->second);
+  }
+  ret.program = std::make_shared<plaidml::edsl::Program>(plaidml::edsl::ProgramBuilder(fused_node->Name(), output_tensors).compile());
+  return ret;
+}
 
 PlaidMLExecutionProvider::PlaidMLExecutionProvider(const PlaidMLExecutionProviderInfo& info)
     : IExecutionProvider{onnxruntime::kPlaidMLExecutionProvider} {
   ORT_UNUSED_PARAMETER(info);
 
-  // TODO: I'm reusing the Allocator setup from OpenVINO. Is that right?
+  // This Allocator setup is ported fairly directly from the OpenVINO version.
+  // TODO: Verify that this is the approach we want to take.
   DeviceAllocatorRegistrationInfo device_info(
     {
       OrtMemTypeDefault,
@@ -55,7 +137,7 @@ std::vector<std::unique_ptr<ComputeCapability>> PlaidMLExecutionProvider::GetCap
     return result;
   }
 
-  // TODO: this is taken fairly directly from nGraph's approach; verify it makes sense
+  // This was modeled off of the metadata that nGraph included
   auto meta_def = onnxruntime::make_unique<IndexedSubGraph::MetaDef>();
   meta_def->name = "PlaidML_Fully_Fused_Graph";
   meta_def->domain = kPlaidMLDomain;
@@ -68,18 +150,66 @@ std::vector<std::unique_ptr<ComputeCapability>> PlaidMLExecutionProvider::GetCap
   sub_graph->nodes = graph_viewer.GetNodesInTopologicalOrder();
   sub_graph->SetMetaDef(meta_def);
   result.push_back(onnxruntime::make_unique<ComputeCapability>(std::move(sub_graph)));
-  // /end TODO: verify
 
   return result;
 }
 
 common::Status PlaidMLExecutionProvider::Compile(
-    const std::vector<onnxruntime::Node*>& /*fused_nodes*/,
-    std::vector<NodeComputeInfo>& /*node_compute_funcs*/) {
+    const std::vector<onnxruntime::Node*>& fused_nodes,
+    std::vector<NodeComputeInfo>& node_compute_funcs) {
+  for (auto fused_node : fused_nodes) {
+    NodeComputeInfo compute_info;
 
-  // TODO: This is a do-nothing stub. Implement!
+    compute_info.create_state_func =
+        [pml_program = std::make_shared<PlaidMLProgram>(MakePlaidMLProgram(fused_node))](ComputeContext* /*context*/, FunctionState* state) {
+          auto* pml_state = new PlaidMLFunctionState();
+          pml_state->program = pml_program;
+          *state = pml_state;
+          return 0;
+        };
+    compute_info.compute_func =
+        [](FunctionState state, const OrtCustomOpApi* api, OrtKernelContext* context) {
+          // TODO: nGraph code has mutexs all over this stuff, is that something we should be concerned with?
 
-  return common::Status(common::ONNXRUNTIME, common::NOT_IMPLEMENTED);
+          Ort::CustomOpApi ort{*api};
+          auto pml_state = static_cast<PlaidMLFunctionState*>(state);
+          auto binder = plaidml::exec::Binder(*pml_state->program->program);
+
+          // Load input data
+          auto executable = binder.compile();
+          unsigned input_idx = 0;
+          for (auto input_placeholder : pml_state->program->inputs) {
+            // program->inputs and ORT inputs are in the same order, so these match
+            const OrtValue* input_value = ort.KernelContext_GetInput(context, input_idx++);
+            void* input_data = const_cast<void*>(ort.GetTensorData<void>(input_value));
+            binder.input(input_placeholder).copy_from(input_data);
+          }
+
+          executable->run();
+
+          // Write output data
+          unsigned output_idx = 0;
+          for (auto output_arg : pml_state->program->program->outputs()) {
+            std::vector<int64_t> ort_shape = output_arg.shape.sizes();
+            OrtValue* output_value = ort.KernelContext_GetOutput(context, output_idx++, ort_shape.data(), ort_shape.size());
+            void* output_data = ort.GetTensorMutableData<void>(output_value);
+            binder.output(output_arg.tensor).copy_into(output_data);
+          }
+
+          return Status::OK();
+        };
+
+    compute_info.release_state_func =
+        [](FunctionState state) {
+          if (state) {
+            auto* function_state = static_cast<PlaidMLFunctionState*>(state);
+            delete function_state;
+          }
+        };
+
+    node_compute_funcs.push_back(compute_info);
+  }
+  return Status::OK();
 }
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/plaidml/plaidml_execution_provider.cc
+++ b/onnxruntime/core/providers/plaidml/plaidml_execution_provider.cc
@@ -5,6 +5,8 @@
 #include "core/framework/compute_capability.h"
 #include "core/graph/model.h"
 
+#include "core/framework/allocatormgr.h"  // TODO: For DeviceAllocatorRegistrationInfo
+
 // TODO: Actually use this
 #include "plaidml/edsl/edsl.h"
 
@@ -16,17 +18,57 @@ PlaidMLExecutionProvider::PlaidMLExecutionProvider(const PlaidMLExecutionProvide
     : IExecutionProvider{onnxruntime::kPlaidMLExecutionProvider} {
   ORT_UNUSED_PARAMETER(info);
 
-  // TODO: This is a do-nothing ctor; that might be correct, but if not implement!
+  // TODO: I'm reusing the Allocator setup from OpenVINO. Is that right?
+  DeviceAllocatorRegistrationInfo device_info(
+    {
+      OrtMemTypeDefault,
+      [](int) {
+        return onnxruntime::make_unique<CPUAllocator>(
+          onnxruntime::make_unique<OrtMemoryInfo>(PLAIDML, OrtDeviceAllocator)
+        );
+      },
+      std::numeric_limits<size_t>::max()
+    }
+  );
+  InsertAllocator(CreateAllocator(device_info));
 }
 
 std::vector<std::unique_ptr<ComputeCapability>> PlaidMLExecutionProvider::GetCapability(
-    const onnxruntime::GraphViewer& /*graph_viewer*/,
+    const onnxruntime::GraphViewer& graph_viewer,
     const std::vector<const KernelRegistry*>& /*kernel_registries*/) const {
+  // TODO: This is a basic implementation that does not handle graph partitioning, incompatible
+  // operation detection, initializers as inputs (for e.g. weights, reshape, ...), and probably
+  // other things. But it should work in the basic case.
+  // Loosely based on the nGraph approach
   std::vector<std::unique_ptr<ComputeCapability>> result;
+  std::vector<std::string> inputs;
+  std::vector<std::string> outputs;
 
-  // TODO: This is a do-nothing stub. Implement!
+  std::for_each(graph_viewer.GetInputs().begin(), graph_viewer.GetInputs().end(),
+                [&inputs](const NodeArg* node_arg) { inputs.push_back(node_arg->Name()); });
 
-  throw std::runtime_error("TODO: PlaidMLExecutionProvider::GetCapability is not yet implemented");
+  std::for_each(graph_viewer.GetOutputs().begin(), graph_viewer.GetOutputs().end(),
+                [&outputs](const NodeArg* node_arg) { outputs.push_back(node_arg->Name()); });
+
+  // If there are no inputs, leave it for constant folding
+  if (inputs.empty()) {
+    return result;
+  }
+
+  // TODO: this is taken fairly directly from nGraph's approach; verify it makes sense
+  auto meta_def = onnxruntime::make_unique<IndexedSubGraph::MetaDef>();
+  meta_def->name = "PlaidML_Fully_Fused_Graph";
+  meta_def->domain = kPlaidMLDomain;
+  meta_def->since_version = 1;
+  meta_def->status = ONNX_NAMESPACE::EXPERIMENTAL;
+  meta_def->inputs = inputs;
+  meta_def->outputs = outputs;
+
+  std::unique_ptr<IndexedSubGraph> sub_graph = onnxruntime::make_unique<IndexedSubGraph>();
+  sub_graph->nodes = graph_viewer.GetNodesInTopologicalOrder();
+  sub_graph->SetMetaDef(meta_def);
+  result.push_back(onnxruntime::make_unique<ComputeCapability>(std::move(sub_graph)));
+  // /end TODO: verify
 
   return result;
 }

--- a/onnxruntime/core/providers/plaidml/plaidml_execution_provider.cc
+++ b/onnxruntime/core/providers/plaidml/plaidml_execution_provider.cc
@@ -1,0 +1,38 @@
+// Copyright(C) 2020 Intel Corporation
+// Licensed under the MIT License
+
+// TODO: Other includes?
+#include "core/framework/compute_capability.h"
+#include "core/graph/model.h"
+
+#include "plaidml_execution_provider.h"
+
+namespace onnxruntime {
+
+PlaidMLExecutionProvider::PlaidMLExecutionProvider(const PlaidMLExecutionProviderInfo& info)
+    : IExecutionProvider{onnxruntime::kPlaidMLExecutionProvider} {
+  ORT_UNUSED_PARAMETER(info);
+
+  // TODO: This is a do-nothing ctor; that might be correct, but if not implement!
+}
+
+std::vector<std::unique_ptr<ComputeCapability>> PlaidMLExecutionProvider::GetCapability(
+    const onnxruntime::GraphViewer& /*graph_viewer*/,
+    const std::vector<const KernelRegistry*>& /*kernel_registries*/) const {
+  std::vector<std::unique_ptr<ComputeCapability>> result;
+
+  // TODO: This is a do-nothing stub. Implement!
+
+  return result;
+}
+
+common::Status PlaidMLExecutionProvider::Compile(
+    const std::vector<onnxruntime::Node*>& /*fused_nodes*/,
+    std::vector<NodeComputeInfo>& /*node_compute_funcs*/) {
+
+  // TODO: This is a do-nothing stub. Implement!
+
+  return common::Status(common::ONNXRUNTIME, common::NOT_IMPLEMENTED);
+}
+
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/plaidml/plaidml_execution_provider.cc
+++ b/onnxruntime/core/providers/plaidml/plaidml_execution_provider.cc
@@ -26,6 +26,8 @@ std::vector<std::unique_ptr<ComputeCapability>> PlaidMLExecutionProvider::GetCap
 
   // TODO: This is a do-nothing stub. Implement!
 
+  throw std::runtime_error("TODO: PlaidMLExecutionProvider::GetCapability is not yet implemented");
+
   return result;
 }
 

--- a/onnxruntime/core/providers/plaidml/plaidml_execution_provider.cc
+++ b/onnxruntime/core/providers/plaidml/plaidml_execution_provider.cc
@@ -5,6 +5,9 @@
 #include "core/framework/compute_capability.h"
 #include "core/graph/model.h"
 
+// TODO: Actually use this
+#include "plaidml/edsl/edsl.h"
+
 #include "plaidml_execution_provider.h"
 
 namespace onnxruntime {

--- a/onnxruntime/core/providers/plaidml/plaidml_execution_provider.h
+++ b/onnxruntime/core/providers/plaidml/plaidml_execution_provider.h
@@ -7,6 +7,8 @@
 
 namespace onnxruntime {
 
+constexpr const char* PLAIDML = "PlaidML";  // TODO: Borrowed from OpenVINO. Reasonable?
+
 // Information needed to construct PlaidML execution providers.
 struct PlaidMLExecutionProviderInfo {
     // TODO: Empty for now. Forever?

--- a/onnxruntime/core/providers/plaidml/plaidml_execution_provider.h
+++ b/onnxruntime/core/providers/plaidml/plaidml_execution_provider.h
@@ -1,0 +1,32 @@
+// Copyright(C) 2020 Intel Corporation
+// Licensed under the MIT License
+
+#pragma once
+
+#include "core/framework/execution_provider.h"
+
+namespace onnxruntime {
+
+// Information needed to construct PlaidML execution providers.
+struct PlaidMLExecutionProviderInfo {
+    // TODO: Empty for now. Forever?
+};
+
+class PlaidMLExecutionProvider : public IExecutionProvider {
+ public:
+  explicit PlaidMLExecutionProvider(const PlaidMLExecutionProviderInfo& info);
+  ~PlaidMLExecutionProvider() = default;
+
+  std::vector<std::unique_ptr<ComputeCapability>>
+  GetCapability(const onnxruntime::GraphViewer& graph_viewer,
+                const std::vector<const KernelRegistry*>& kernel_registries) const override;
+
+  Status Compile(const std::vector<onnxruntime::Node*>& fused_nodes,
+                 std::vector<NodeComputeInfo>& node_compute_funcs) override;
+
+ private:
+  // TODO: PlaidML-specific state goes here; if info_ is truly empty, don't need it here
+  // PlaidMLExecutionProviderInfo info_;
+};
+
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/plaidml/plaidml_execution_provider.h
+++ b/onnxruntime/core/providers/plaidml/plaidml_execution_provider.h
@@ -5,13 +5,30 @@
 
 #include "core/framework/execution_provider.h"
 
+namespace plaidml {
+namespace edsl {
+class Program;
+class Tensor;
+}  // namespace edsl
+}  // namespace plaidml
+
 namespace onnxruntime {
 
 constexpr const char* PLAIDML = "PlaidML";  // TODO: Borrowed from OpenVINO. Reasonable?
 
+struct PlaidMLProgram {
+  // A PlaidML Program bundled with its (ordered) input placeholder tensors
+  std::shared_ptr<plaidml::edsl::Program> program;
+  std::vector<plaidml::edsl::Tensor> inputs;
+};
+
+struct PlaidMLFunctionState {
+  std::shared_ptr<PlaidMLProgram> program = nullptr;
+};
+
 // Information needed to construct PlaidML execution providers.
 struct PlaidMLExecutionProviderInfo {
-    // TODO: Empty for now. Forever?
+    // TODO: Empty for now. Forever? -- if so we can scrap this struct altogether
 };
 
 class PlaidMLExecutionProvider : public IExecutionProvider {

--- a/onnxruntime/core/providers/plaidml/plaidml_provider_factory.cc
+++ b/onnxruntime/core/providers/plaidml/plaidml_provider_factory.cc
@@ -2,6 +2,10 @@
 // Licensed under the MIT License
 
 #include "core/providers/plaidml/plaidml_provider_factory.h"
+
+#include "plaidml/edsl/edsl.h"
+#include "plaidml/exec/exec.h"
+
 #include "plaidml_execution_provider.h"
 #include "core/session/abi_session_options_impl.h"
 
@@ -18,6 +22,8 @@ struct PlaidMLProviderFactory : IExecutionProviderFactory {
 };
 
 std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_PlaidML() {
+  plaidml::edsl::init();
+  plaidml::exec::init();
   return std::make_shared<onnxruntime::PlaidMLProviderFactory>();
 }
 

--- a/onnxruntime/core/providers/plaidml/plaidml_provider_factory.cc
+++ b/onnxruntime/core/providers/plaidml/plaidml_provider_factory.cc
@@ -1,0 +1,31 @@
+// Copyright(C) 2020 Intel Corporation
+// Licensed under the MIT License
+
+#include "core/providers/plaidml/plaidml_provider_factory.h"
+#include "plaidml_execution_provider.h"
+#include "core/session/abi_session_options_impl.h"
+
+namespace onnxruntime {
+
+struct PlaidMLProviderFactory : IExecutionProviderFactory {
+  PlaidMLProviderFactory() = default;
+  ~PlaidMLProviderFactory() = default;
+
+  std::unique_ptr<IExecutionProvider> CreateProvider() override {
+    PlaidMLExecutionProviderInfo info{};
+    return onnxruntime::make_unique<PlaidMLExecutionProvider>(info);
+  }
+};
+
+std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_PlaidML() {
+  return std::make_shared<onnxruntime::PlaidMLProviderFactory>();
+}
+
+}  // namespace onnxruntime
+
+ORT_API_STATUS_IMPL(OrtSessionOptionsAppendExecutionProvider_PlaidML,
+                    _In_ OrtSessionOptions* options) {
+  options->provider_factories.push_back(
+      onnxruntime::CreateExecutionProviderFactory_PlaidML());
+  return nullptr;
+}

--- a/onnxruntime/core/providers/plaidml/symbols.txt
+++ b/onnxruntime/core/providers/plaidml/symbols.txt
@@ -1,0 +1,1 @@
+OrtSessionOptionsAppendExecutionProvider_PlaidML

--- a/onnxruntime/test/framework/test_utils.cc
+++ b/onnxruntime/test/framework/test_utils.cc
@@ -43,6 +43,15 @@ IExecutionProvider* TestNnapiExecutionProvider() {
 }
 #endif
 
+#ifdef USE_PLAIDML
+IExecutionProvider* TestPlaidMLExecutionProvider() {
+  static PlaidMLExecutionProviderInfo info;
+  static PlaidMLExecutionProvider plaidml_provider(info);
+  return &plaidml_provider;
+}
+#endif
+
+
 static void CountOpsInGraphImpl(const Graph& graph, std::map<std::string, int>& ops) {
   for (auto& node : graph.Nodes()) {
     auto pos = ops.find(node.OpType());

--- a/onnxruntime/test/framework/test_utils.h
+++ b/onnxruntime/test/framework/test_utils.h
@@ -24,6 +24,9 @@
 #ifdef USE_NNAPI
 #include "core/providers/nnapi/nnapi_execution_provider.h"
 #endif
+#ifdef USE_PLAIDML
+#include "core/providers/plaidml/plaidml_execution_provider.h"
+#endif
 
 namespace onnxruntime {
 class Graph;
@@ -48,6 +51,10 @@ IExecutionProvider* TestOpenVINOExecutionProvider();
 
 #ifdef USE_NNAPI
 IExecutionProvider* TestNnapiExecutionProvider();
+#endif
+
+#ifdef USE_PLAIDML
+IExecutionProvider* TestPlaidMLExecutionProvider();
 #endif
 
 template <typename T>

--- a/onnxruntime/test/providers/plaidml/plaidml_execution_provider_test.cc
+++ b/onnxruntime/test/providers/plaidml/plaidml_execution_provider_test.cc
@@ -1,0 +1,85 @@
+// Copyright(C) 2020 Intel Corporation
+// Licensed under the MIT License
+
+#include "core/providers/plaidml/plaidml_execution_provider.h"
+#include "test/providers/provider_test_utils.h"
+#include "default_providers.h"
+#include "gtest/gtest.h"
+#include "core/session/inference_session.h"
+#include "test/framework/test_utils.h"
+
+namespace onnxruntime {
+namespace test {
+
+// TODO: This is based on the nGraph tests, investigate if we want something different
+void RunTest(
+    const std::string& model_path,
+    const NameMLValMap& feeds,
+    const std::vector<std::string>& output_names,
+    const std::vector<std::vector<int64_t>>& expected_shapes,
+    const std::vector<std::vector<float>>& expected_values) {
+  SessionOptions so;
+  InferenceSession session_object(so, &DefaultLoggingManager());
+
+  auto status = session_object.RegisterExecutionProvider(DefaultPlaidMLExecutionProvider());
+  ASSERT_TRUE(status.IsOK()) << status.ErrorMessage();
+
+  status = session_object.Load(model_path);
+  ASSERT_TRUE(status.IsOK()) << status.ErrorMessage();
+
+  status = session_object.Initialize();
+  ASSERT_TRUE(status.IsOK()) << status.ErrorMessage();
+
+  RunOptions run_options{};
+  run_options.run_tag = "PlaidML EP test tag";
+  run_options.run_log_verbosity_level = 1;
+
+  std::vector<OrtValue> fetches;
+  status = session_object.Run(run_options, feeds, output_names, &fetches);
+  ASSERT_TRUE(status.IsOK()) << status.ErrorMessage();
+
+  if (!status.IsOK()) {
+    LOGS_DEFAULT(ERROR) << "Run failed with status: " << status.ErrorMessage();
+    return;
+  }
+
+  for (size_t idx = 0; idx < expected_values.size(); ++idx) {
+    auto& got_tensor = fetches[idx].Get<Tensor>();
+    auto* got = got_tensor.Data<float>();
+    auto& expected = expected_values[idx];
+    TensorShape expected_shape(expected_shapes[idx]);
+    EXPECT_EQ(got_tensor.Shape(), expected_shape);
+    for (size_t i = 0; i < expected.size(); i++) {
+      EXPECT_EQ(got[i], expected[i]);
+    }
+  }
+}
+
+// TODO: This is separated out as in nGraph, but I think we may want to make it integrated
+void add_feeds(NameMLValMap& feeds, std::string name, std::vector<int64_t> dims, std::vector<float> value) {
+  OrtValue ml_value;
+
+  auto allocator = TestPlaidMLExecutionProvider()->GetAllocator(0, OrtMemTypeDefault);
+  ASSERT_TRUE(allocator) << "Attempting to get allocator for input tensors yielded null pointer";
+  CreateMLValue<float>(allocator, dims, value, &ml_value);
+
+  feeds.insert(std::make_pair(name, ml_value));
+}
+
+TEST(PlaidMLExecutionProviderTest, Basic_Test) {
+  NameMLValMap feeds;
+  add_feeds(feeds, "A", {4}, {1.0f, 2.0f, 3.0f, 4.0f});
+  add_feeds(feeds, "B", {4}, {2.0f, 2.0f, 2.0f, 2.0f});
+
+  std::vector<std::vector<float>> expected_values = {
+      {4.0f, 8.0f, 12.0f, 16.0f}};
+
+  std::vector<std::vector<int64_t>> expected_shapes = {
+      {4}};
+
+  // TODO: We're borrowing nGraph test data just to get something basic going, but switch to our own network & inputs eventually
+  RunTest("testdata/ngraph/Basic_Test.onnx", feeds, {"Z"}, expected_shapes, expected_values);
+}
+
+}  // namespace test
+}  // namespace onnxruntime

--- a/onnxruntime/test/util/default_providers.cc
+++ b/onnxruntime/test/util/default_providers.cc
@@ -17,6 +17,7 @@ std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_Nnapi(
 std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_Tensorrt(int device_id);
 std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_OpenVINO(const char* device_id);
 std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_ACL(int use_arena);
+std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_PlaidML();
 
 namespace test {
 
@@ -87,6 +88,14 @@ std::unique_ptr<IExecutionProvider> DefaultAclExecutionProvider(bool enable_aren
   return CreateExecutionProviderFactory_ACL(enable_arena)->CreateProvider();
 #else
   ORT_UNUSED_PARAMETER(enable_arena);
+  return nullptr;
+#endif
+}
+
+std::unique_ptr<IExecutionProvider> DefaultPlaidMLExecutionProvider() {
+#ifdef USE_PLAIDML
+  return CreateExecutionProviderFactory_PlaidML()->CreateProvider();
+#else
   return nullptr;
 #endif
 }

--- a/onnxruntime/test/util/include/default_providers.h
+++ b/onnxruntime/test/util/include/default_providers.h
@@ -16,6 +16,7 @@ std::unique_ptr<IExecutionProvider> DefaultTensorrtExecutionProvider();
 std::unique_ptr<IExecutionProvider> DefaultOpenVINOExecutionProvider();
 std::unique_ptr<IExecutionProvider> DefaultNnapiExecutionProvider();
 std::unique_ptr<IExecutionProvider> DefaultAclExecutionProvider(bool enable_arena = true);
+std::unique_ptr<IExecutionProvider> DefaultPlaidMLExecutionProvider();
 
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/util/include/providers.h
+++ b/onnxruntime/test/util/include/providers.h
@@ -31,3 +31,6 @@
 #ifdef USE_ACL
 #include "core/providers/acl/acl_provider_factory.h"
 #endif
+#ifdef USE_PLAIDML
+#include "core/providers/plaidml/plaidml_provider_factory.h"
+#endif

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -136,6 +136,7 @@ Use the individual flags to only run the specified stages.
     parser.add_argument("--use_gemmlowp", action='store_true', help="Build with gemmlowp for quantized gemm.")
     parser.add_argument("--use_featurizers", action='store_true', help="Build with ML Featurizer support.")
     parser.add_argument("--use_ngraph", action='store_true', help="Build with nGraph.")
+    parser.add_argument("--use_plaidml", action='store_true', help="Build with PlaidML.")
     parser.add_argument("--use_openvino", nargs="?", const="CPU_FP32",
                         choices=["CPU_FP32","GPU_FP32","GPU_FP16","VAD-M_FP16","MYRIAD_FP16","VAD-F_FP32"], help="Build with OpenVINO for specific hardware.")
     parser.add_argument("--use_dnnlibrary", action='store_true', help="Build with DNNLibrary.")
@@ -320,6 +321,7 @@ def generate_build_tree(cmake_path, source_dir, build_dir, cuda_home, cudnn_home
                  "-Donnxruntime_USE_MKLML=" + ("ON" if args.use_mklml else "OFF"),
                  "-Donnxruntime_USE_GEMMLOWP=" + ("ON" if args.use_gemmlowp else "OFF"),
                  "-Donnxruntime_USE_NGRAPH=" + ("ON" if args.use_ngraph else "OFF"),
+                 "-Donnxruntime_USE_PLAIDML=" + ("ON" if args.use_plaidml else "OFF"),
                  "-Donnxruntime_USE_OPENVINO=" + ("ON" if args.use_openvino else "OFF"),
                  "-Donnxruntime_USE_OPENVINO_MYRIAD=" + ("ON" if args.use_openvino == "MYRIAD_FP16" else "OFF"),
                  "-Donnxruntime_USE_OPENVINO_GPU_FP32=" + ("ON" if args.use_openvino == "GPU_FP32" else "OFF"),


### PR DESCRIPTION
This is a minimum PlaidML execution provider to ONNX RT to perform elementwise addition of two tensors. It glosses over and otherwise avoids many details that will be necessary for running real networks. I think now is a good point to discuss features that will need to be implemented and design decisions that will need to be made in order to execute practical workloads.

Probably the largest design decision is whether to analyze an ONNX Runtime `Node` object (n.b. such "`Node`"s are actually usually fused graphs and will in many cases be an entire network) or whether to analyze a classic ONNX ModelProto. Some of the tradeoffs I see:
 * The code needed for generating a ModelProto is likely more useable for writing a non-RT ONNX backend, if we decide to do that.
 * A ModelProto is documented as part of the mainline ONNX docs, which are extremely thorough. I've found the ONNX RT documentation to be good as well, but it's not quite as thorough.
 * Both nGraph and OpenVINO utilize a ModelProto approach, so we have examples if we go with this approach.
 * The ONNXRT Node analysis approach is what the current code uses.
 * If we stick with ONNXRT Nodes, we don't have a convert-to-proto step and the corresponding extra API and possibility for bugs
 * Interpreting an ONNXRT Node may not be sufficiently complex to merit an extra conversion.

For either approach, what we want to produce is what I currently call a `PlaidMLProgram`; that is, a `plaidml::edsl::Program` plus an appropriately-ordered `std::vector<plaidml::edsl::Tensor>` containing the input placeholders. The `ModelProto` approach would involving rewriting `MakePlaidMLProgram` to convert the `onnxruntime::Node*` to a `ModelProto` and then constructing a `PlaidMLProgram` from that `ModelProto`. The `Node` approach would involve extending the `MakePlaidMLOp` function currently called by `MakePlaidMLProgram` to analyze the `NodeProto` it is given and perform the corresponding eDSL operation.

The other large design decision I see is how much network parsing we want to manage in the `GetCapability` function. There are two major features we provide for ONNXRT: `GetCapability`, where we tell ONNXRT what subgraphs we can execute, and `Compile`, where we execute whichever of those subgraphs ONNXRT requests from us. Since we need to analyze a network for whether it is within our capabilities during `GetCapability` anyway, we may find it beneficial to also do some compilation work there and cache it for when `Compile` is called.

At present, we tell ONNXRT we can execute the entire network it gives us during the `GetCapability` stage. We only actually parse and compile the network in the `Compile` stage, and so we don't cache any `GetCapability`-stage data for the `Compile` stage.

There are also a number of missing features, many of which I have noted with TODOs in the code, but I want to call out some ones I think are important:
 * This currently assumes every operation is an elementwise add. We need to analyze the operation and perform what was actually requested.
 * ONNX has both inputs and initializers. This assumes everything is an input, but initializers are also import (for weights, for constants, ...)
 * This doesn't handle symbolic shapes
 * We need some sort of compiled program caching, so that we don't recompile every time.
 * Based off the nGraph code's use of mutexs, I deduce that `compute_info.compute_func` can be called in parallel with itself; we should investigate if anything we're doing there is sensitive to this.
 * Deployment is a complete hack; this only works on a mac and requires some not-ready-for-production environment variables to build

To build this, run (with appropriate modifications to the 2 environment variables)
```
TODO_TEMP_PLAIDML_DIR=<plaidml-source-directory> TODO_TEMP_PLAIDML_LIB_DIR=<plaidml-lib-directory> ./build.sh --config RelWithDebInfo --build_shared_lib --parallel --use_plaidml
```
Note that `<plaidml-lib-directory>` needs to be a directory your Mac finds as well, so e.g. I use `/Users/tzerrell/lib` for `<plaidml-lib-directory>`. It also needs to contain libplaidml.dylib, built from a cmake-friendly edsl.h commit (see https://github.com/plaidml/plaidml/pull/978).

The expected result of a build should be `1 tests failed out of 4`, with the failing test being the first test, which should have the `PlaidMLExecutionProviderTest.Basic_Test` subtest failing with 6 != 8, 8 != 12, and 10 != 16. This is because the current code assumes every operation is elementwise addition, but the test includes both an elementwise multiplication as well.